### PR TITLE
Fix encoder velocity jitter attempt nr. 2

### DIFF
--- a/datavis/decode_and_plot_logs.sh
+++ b/datavis/decode_and_plot_logs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <binary-log-directory> [plot-script-args...]"
+    exit 1
+fi
+
+log_dir=$1
+shift
+
+if [ ! -d "$log_dir" ]; then
+    echo "Error: '$log_dir' is not a directory." >&2
+    exit 1
+fi
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+decoded_dir="$log_dir/decoded"
+plots_dir="$log_dir/plots"
+
+python3 "$script_dir/decode_binary.py" "$log_dir"
+python3 "$script_dir/plot_pololu_log_standalone.py" --log "$decoded_dir" --output "$plots_dir" "$@"
+
+echo "Decoded CSV files: $decoded_dir"
+echo "Plots: $plots_dir"

--- a/datavis/decode_binary.py
+++ b/datavis/decode_binary.py
@@ -76,10 +76,19 @@ def is_compact_format(bin_file, start_pos):
     return True
 
 
-def decode_file(input_path):
+def csv_output_path(input_path, output_dir=None):
+    filename = os.path.basename(input_path) + ".csv"
+    if output_dir is not None:
+        return os.path.join(output_dir, filename)
+    return os.path.join(os.path.dirname(input_path), filename)
+
+
+def decode_file(input_path, output_path=None):
     if not os.path.exists(input_path):
         print(f"Error: File '{input_path}' does not exist.")
         return False
+    if output_path is None:
+        output_path = csv_output_path(input_path)
         
     print(f"Reading binary file: {input_path}")
     with open(input_path, "rb") as bin_file:
@@ -89,12 +98,7 @@ def decode_file(input_path):
             print(f"Error: Invalid file format (expected magic header {MAGIC_HEADER.hex()}, got {magic.hex()})")
             return False
         
-        # Detect format by checking file size after header
         current_pos = bin_file.tell()
-        bin_file.seek(0, 2)  # seek to end
-        data_size = bin_file.tell() - current_pos
-        
-        # Check if compact format
         is_compact = is_compact_format(bin_file, current_pos)
         bin_file.seek(current_pos)  # seek back
         
@@ -103,8 +107,6 @@ def decode_file(input_path):
             print("Detected Compact Tagged Binary format")
             csv_header = CSV_HEADER
             float_counts = {1: 6, 2: 5, 3: 2, 4: 3, 5: 2, 6: 2, 7: 6, 8: 5, 9: 6}
-            current_row = [""] * 29
-            current_ts = None
             while True:
                 header_chunk = bin_file.read(5)
                 if not header_chunk:
@@ -122,26 +124,18 @@ def decode_file(input_path):
                     print("Warning: Trailing partial payload ignored")
                     break
                 unpacked = struct.unpack(f"<{num_floats}f", payload_chunk)
-                
-                # Coalesce rows within a 2ms window
-                if current_ts is None or abs(t_ms - current_ts) > 2:
-                    if current_ts is not None:
-                        records.append(",".join(current_row))
-                    current_row = [""] * 29
-                    current_row[0] = str(t_ms)
-                    current_ts = t_ms
-                
+
+                current_row = [""] * 29
+                current_row[0] = str(t_ms)
                 map_tag_to_row(tag, unpacked, current_row)
-                
-            if current_ts is not None:
                 records.append(",".join(current_row))
         else:
             print(f"Error: Unsupported legacy binary format. Only Compact Tagged Binary logs can be decoded.")
             return False
             
-    # Overwrite the original binary file with the CSV content
-    print(f"Overwriting binary file with CSV data: {input_path}")
-    with open(input_path, "w") as csv_file:
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    print(f"Writing CSV data: {output_path}")
+    with open(output_path, "w") as csv_file:
         csv_file.write(csv_header)
         for record in records:
             csv_file.write(record + "\n")
@@ -155,11 +149,12 @@ def main():
         sys.exit(1)
         
     success = True
-    paths_to_decode = []
+    decode_jobs = []
     
     for arg in sys.argv[1:]:
         if os.path.isdir(arg):
             print(f"Scanning directory: {arg}")
+            output_dir = os.path.join(arg, "decoded")
             for entry in sorted(os.listdir(arg)):
                 full_path = os.path.join(arg, entry)
                 if os.path.isfile(full_path) and entry.startswith("TR") and not entry.endswith(".png") and not entry.endswith(".csv"):
@@ -167,18 +162,18 @@ def main():
                         with open(full_path, "rb") as f:
                             magic = f.read(4)
                             if magic == MAGIC_HEADER:
-                                paths_to_decode.append(full_path)
+                                decode_jobs.append((full_path, csv_output_path(full_path, output_dir)))
                     except Exception:
                         pass
         else:
-            paths_to_decode.append(arg)
+            decode_jobs.append((arg, csv_output_path(arg)))
             
-    if not paths_to_decode:
+    if not decode_jobs:
         print("No matching binary log files found to decode.")
         return
         
-    for path in paths_to_decode:
-        if not decode_file(path):
+    for input_path, output_path in decode_jobs:
+        if not decode_file(input_path, output_path):
             success = False
             
     if not success:

--- a/datavis/plot_pololu_log_standalone.py
+++ b/datavis/plot_pololu_log_standalone.py
@@ -49,13 +49,13 @@ def looks_like_log(path: Path) -> bool:
 
 
 def log_files(directory: Path) -> list[Path]:
-    paths = sorted(path for path in directory.iterdir() if path.is_file() and looks_like_log(path))
+    paths = sorted(path for path in directory.iterdir() if path.is_file() and path.suffix.lower() == ".csv")
     if not paths:
-        raise ValueError(f"No Pololu log files found in {directory}")
+        raise ValueError(f"No CSV files found in {directory}")
     return paths
 
 
-def load_columns(path: str | Path) -> tuple[list[str], np.ndarray]:
+def load_columns(path: str | Path, max_time: float | None = None) -> tuple[list[str], np.ndarray]:
     data = np.genfromtxt(path, delimiter=",", names=True, dtype=float)
     columns = list(data.dtype.names or ())
     values = np.column_stack([data[name] for name in columns])
@@ -64,6 +64,13 @@ def load_columns(path: str | Path) -> tuple[list[str], np.ndarray]:
     ts_index = columns.index("ts")
     values = values[np.isfinite(values[:, ts_index])]
     values = values[np.argsort(values[:, ts_index])]
+    if max_time is not None:
+        if max_time < 0:
+            raise ValueError("--max-time must be non-negative")
+        start_ts = values[0, ts_index]
+        values = values[(values[:, ts_index] - start_ts) / 1000.0 <= max_time]
+        if len(values) == 0:
+            raise ValueError(f"No rows available in {path}")
     values = values.copy()
     values[:, ts_index] = (values[:, ts_index] - values[0, ts_index]) / 1000.0
     return columns, values
@@ -114,8 +121,13 @@ def clip_after_first_trajectory(columns: list[str], data: np.ndarray, min_zero_r
     return data
 
 
-def plot_log(log_path: str | Path, output_path: str | Path, clip: bool = False):
-    columns, data = load_columns(log_path)
+def plot_log(
+    log_path: str | Path,
+    output_path: str | Path,
+    clip: bool = False,
+    max_time: float | None = None,
+):
+    columns, data = load_columns(log_path, max_time=max_time)
     if clip:
         data = clip_after_first_trajectory(columns, data)
 
@@ -207,24 +219,24 @@ def plot_log(log_path: str | Path, output_path: str | Path, clip: bool = False):
 
 def main():
     parser = argparse.ArgumentParser(description="Standalone Pololu log summary plotter.")
-    parser.add_argument("log")
+    parser.add_argument("--log", default="Pololu Data/Experiments/2026_06_27 Johannes Encoder RAM/")
     parser.add_argument("--output", default=None)
     parser.add_argument("--clip-after-first-trajectory", default=True)
+    parser.add_argument("--max-time", type=float, default=5)
     args = parser.parse_args()
 
     log_path = Path(args.log)
     if log_path.is_dir():
-        output_dir = Path(args.output) if args.output is not None else log_path
-        output_dir = output_dir / log_path.name
+        output_dir = Path(args.output) if args.output is not None else log_path / "plots"
         output_dir.mkdir(parents=True, exist_ok=True)
         for path in log_files(log_path):
             output_path = output_dir / f"{path.stem}.pdf"
-            plot_log(path, output_path, clip=args.clip_after_first_trajectory)
+            plot_log(path, output_path, clip=args.clip_after_first_trajectory, max_time=args.max_time)
             print(output_path)
         return
 
     output_path = Path(args.output) if args.output is not None else log_path.with_suffix(".pdf")
-    plot_log(log_path, output_path, clip=args.clip_after_first_trajectory)
+    plot_log(log_path, output_path, clip=args.clip_after_first_trajectory, max_time=args.max_time)
     print(output_path)
 
 

--- a/firmware/src/bin/programm_entrance.rs
+++ b/firmware/src/bin/programm_entrance.rs
@@ -22,7 +22,7 @@ use pololu3pi2040_rs::robotstate;
 use pololu3pi2040_rs::{
     buzzer::{beep_signal, buzzer_beep_task},
     ekf::mocap_update_task,
-    encoder::{EncoderPair, encoder_left_task, encoder_right_task},
+    encoder::start_encoder_irq,
     inner_controller::wheel_speed_inner_loop,
     joystick_control::{control_action_uart_task, teleop_motor_control_task, teleop_uart_task},
     led::LED_SHARED,
@@ -189,18 +189,9 @@ pub async fn orchestrator(spawner: Spawner, mut devices: init::InitDevices<'stat
     }
 
     // ================ Spawn Encoder Task ==========================
-    let EncoderPair {
-        encoder_left,
-        encoder_right,
-    } = devices.encoders;
     let encoder_count_left = devices.encoder_counts.left;
     let encoder_count_right = devices.encoder_counts.right;
-    spawner
-        .spawn(encoder_left_task(encoder_left, encoder_count_left))
-        .unwrap();
-    spawner
-        .spawn(encoder_right_task(encoder_right, encoder_count_right))
-        .unwrap();
+    start_encoder_irq(devices.encoders);
 
     // ============= spawn low level uart task ======================
     spawner.spawn(uart_hw_task(devices.uart)).unwrap();

--- a/firmware/src/bin/teleop_control.rs
+++ b/firmware/src/bin/teleop_control.rs
@@ -7,7 +7,7 @@ use embassy_executor::Spawner;
 use embassy_rp::init;
 
 use pololu3pi2040_rs::{
-    encoder::{EncoderPair, encoder_left_task, encoder_right_task},
+    encoder::start_encoder_irq,
     init::init_all,
     joystick_control::{get_gear_ratio, teleop_motor_control_task, teleop_uart_task},
     trajectory_uart::UartCfg,
@@ -67,18 +67,9 @@ async fn main(spawner: Spawner) {
         .unwrap();
 
     // === Start Encoder Task ===
-    let EncoderPair {
-        encoder_left,
-        encoder_right,
-    } = devices.encoders;
     let encoder_count_left = devices.encoder_counts.left;
     let encoder_count_right = devices.encoder_counts.right;
-    spawner
-        .spawn(encoder_left_task(encoder_left, encoder_count_left))
-        .unwrap();
-    spawner
-        .spawn(encoder_right_task(encoder_right, encoder_count_right))
-        .unwrap();
+    start_encoder_irq(devices.encoders);
 
     // === Start Control Task ===
     spawner

--- a/firmware/src/bin/trajectory_following.rs
+++ b/firmware/src/bin/trajectory_following.rs
@@ -7,7 +7,7 @@ use {defmt_rtt as _, panic_probe as _};
 use embassy_executor::Spawner;
 use embassy_rp::init;
 
-use pololu3pi2040_rs::encoder::{EncoderPair, encoder_left_task, encoder_right_task};
+use pololu3pi2040_rs::encoder::start_encoder_irq;
 use pololu3pi2040_rs::init::init_all;
 use pololu3pi2040_rs::trajectory_control::{
     diffdrive_outer_loop_command_controlled_traj_following_from_sdcard,
@@ -49,18 +49,9 @@ async fn main(spawner: Spawner) {
 
     // ========================================== Start encoder tasks =================================================
     // =========================== (will be accumulated to ENC_LEFT/RIGHT_DELTA) ======================================
-    let EncoderPair {
-        encoder_left,
-        encoder_right,
-    } = devices.encoders;
     let encoder_count_left = devices.encoder_counts.left;
     let encoder_count_right = devices.encoder_counts.right;
-    spawner
-        .spawn(encoder_left_task(encoder_left, encoder_count_left))
-        .unwrap();
-    spawner
-        .spawn(encoder_right_task(encoder_right, encoder_count_right))
-        .unwrap();
+    start_encoder_irq(devices.encoders);
     // ================================================================================================================
 
     // ======================================== Start Mocap update task ===============================================

--- a/firmware/src/encoder.rs
+++ b/firmware/src/encoder.rs
@@ -1,10 +1,9 @@
 use embassy_rp::peripherals::{PIN_8, PIN_9, PIN_12, PIN_13, PIO0};
 use embassy_rp::pio::{Common, StateMachine};
 // use embassy_rp::pio_programs::rotary_encoder::{Direction, PioEncoder, PioEncoderProgram};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::mutex::Mutex;
+use embassy_rp::{interrupt::typelevel::{Handler, PIO0_IRQ_0}, pac};
 use embassy_time::{Duration, Timer};
-use static_cell::StaticCell;
+use portable_atomic::{AtomicI32, Ordering};
 
 use crate::encoder_lib::{PioEncoder, PioEncoderProgram};
 
@@ -16,18 +15,21 @@ pub struct EncoderPair<'a> {
 
 /// Pair Encoder Counters
 pub struct EncoderCounters {
-    pub left: &'static Mutex<NoopRawMutex, i32>,
-    pub right: &'static Mutex<NoopRawMutex, i32>,
+    pub left: &'static AtomicI32,
+    pub right: &'static AtomicI32,
 }
 
-// Global static cells
-static LEFT_COUNT: StaticCell<Mutex<NoopRawMutex, i32>> = StaticCell::new();
-static RIGHT_COUNT: StaticCell<Mutex<NoopRawMutex, i32>> = StaticCell::new();
+static LEFT_COUNT: AtomicI32 = AtomicI32::new(0);
+static RIGHT_COUNT: AtomicI32 = AtomicI32::new(0);
+static LEFT_PREV_AB: AtomicI32 = AtomicI32::new(-1);
+static RIGHT_PREV_AB: AtomicI32 = AtomicI32::new(-1);
 
 /// avoid using global counters
 pub fn init_encoder_counts() -> EncoderCounters {
-    let left = LEFT_COUNT.init(Mutex::new(0));
-    let right = RIGHT_COUNT.init(Mutex::new(0));
+    LEFT_COUNT.store(0, Ordering::Relaxed);
+    RIGHT_COUNT.store(0, Ordering::Relaxed);
+    let left = &LEFT_COUNT;
+    let right = &RIGHT_COUNT;
     EncoderCounters { left, right }
 }
 
@@ -59,72 +61,63 @@ const LUT: [[i8; 4]; 4] = [
     [0, -1, 1, 0], // 11 ->
 ];
 
-// Left encoder task (read AB and drain the FIFO)
-#[embassy_executor::task]
-pub async fn encoder_left_task(
-    mut encoder: PioEncoder<'static, PIO0, 0>,
-    counter: &'static Mutex<NoopRawMutex, i32>,
-) {
-    let mut prev = encoder.read_ab().await;
-    loop {
-        let mut delta: i32 = 0;
-        let curr = encoder.read_ab().await;
-        delta += LUT[prev as usize][curr as usize] as i32;
-        prev = curr;
+pub struct EncoderPioIrqHandler;
 
-        // fast clean FIFO
-        while let Some(c) = encoder.try_read_ab() {
-            delta += LUT[prev as usize][c as usize] as i32;
-            prev = c;
-        }
-
-        if delta != 0 {
-            let mut g = counter.lock().await;
-            *g = g.wrapping_add(delta);
-
-            crate::robotstate::add_encoder_count_left(delta).await;
-            // defmt::info!("Left encoder count = {}", *g);
-        }
+impl Handler<PIO0_IRQ_0> for EncoderPioIrqHandler {
+    unsafe fn on_interrupt() {
+        drain_encoder_fifo::<0>(&LEFT_COUNT, &LEFT_PREV_AB);
+        drain_encoder_fifo::<1>(&RIGHT_COUNT, &RIGHT_PREV_AB);
+        enable_encoder_irq_sources();
     }
 }
 
-// Left encoder task (read AB and drain the FIFO)
-#[embassy_executor::task]
-pub async fn encoder_right_task(
-    mut encoder: PioEncoder<'static, PIO0, 1>,
-    counter: &'static Mutex<NoopRawMutex, i32>,
-) {
-    let mut prev = encoder.read_ab().await;
-    loop {
-        let mut delta: i32 = 0;
-        let curr = encoder.read_ab().await;
-        delta += LUT[prev as usize][curr as usize] as i32;
+fn drain_encoder_fifo<const SM: usize>(counter: &AtomicI32, prev_ab: &AtomicI32) {
+    let mut prev = prev_ab.load(Ordering::Relaxed);
+    let mut delta = 0i32;
+
+    while pac::PIO0.fstat().read().rxempty() & (1u8 << SM) == 0 {
+        let curr = (pac::PIO0.rxf(SM).read() & 0b11) as i32;
+        if prev >= 0 {
+            delta += LUT[prev as usize][curr as usize] as i32;
+        }
         prev = curr;
-
-        while let Some(c) = encoder.try_read_ab() {
-            delta += LUT[prev as usize][c as usize] as i32;
-            prev = c;
-        }
-
-        if delta != 0 {
-            let mut g = counter.lock().await;
-            *g = g.wrapping_add(delta);
-
-            crate::robotstate::add_encoder_count_right(delta).await;
-            // defmt::info!("Right encoder count = {}", *g);
-        }
     }
+
+    if prev >= 0 {
+        prev_ab.store(prev, Ordering::Relaxed);
+    }
+    if delta != 0 {
+        counter.fetch_add(delta, Ordering::Relaxed);
+    }
+}
+
+pub fn start_encoder_irq(encoders: EncoderPair<'static>) {
+    LEFT_PREV_AB.store(-1, Ordering::Relaxed);
+    RIGHT_PREV_AB.store(-1, Ordering::Relaxed);
+
+    drain_encoder_fifo::<0>(&LEFT_COUNT, &LEFT_PREV_AB);
+    drain_encoder_fifo::<1>(&RIGHT_COUNT, &RIGHT_PREV_AB);
+
+    enable_encoder_irq_sources();
+
+    core::mem::forget(encoders);
+}
+
+fn enable_encoder_irq_sources() {
+    pac::PIO0.irqs(0).inte().modify(|m| {
+        m.0 |= (1 << 0) | (1 << 1);
+    });
 }
 
 // Asychronously acquiring left RPM
 pub async fn get_left_rpm(
-    counter: &'static Mutex<NoopRawMutex, i32>,
+    counter: &'static AtomicI32,
     cpr_wheel: f32,
     interval_ms: u64,
 ) -> f32 {
-    let before = *counter.lock().await;
+    let before = counter.load(Ordering::Relaxed);
     Timer::after(Duration::from_millis(interval_ms)).await;
-    let after = *counter.lock().await;
+    let after = counter.load(Ordering::Relaxed);
 
     let delta = after.wrapping_sub(before) as f32;
     let rps = delta / cpr_wheel / (interval_ms as f32 / 1000.0);
@@ -133,13 +126,13 @@ pub async fn get_left_rpm(
 
 // Asychronously acquiring right RPM
 pub async fn get_right_rpm(
-    counter: &'static Mutex<NoopRawMutex, i32>,
+    counter: &'static AtomicI32,
     cpr_wheel: f32,
     interval_ms: u64,
 ) -> f32 {
-    let before = *counter.lock().await;
+    let before = counter.load(Ordering::Relaxed);
     Timer::after(Duration::from_millis(interval_ms)).await;
-    let after = *counter.lock().await;
+    let after = counter.load(Ordering::Relaxed);
 
     let delta = after.wrapping_sub(before) as f32;
     let rps = delta / cpr_wheel / (interval_ms as f32 / 1000.0);
@@ -147,18 +140,18 @@ pub async fn get_right_rpm(
 }
 
 pub async fn get_rpms(
-    left_counter: &'static Mutex<NoopRawMutex, i32>,
-    right_counter: &'static Mutex<NoopRawMutex, i32>,
+    left_counter: &'static AtomicI32,
+    right_counter: &'static AtomicI32,
     cpr_wheel: f32,
     interval_ms: u64,
 ) -> (f32, f32) {
-    let left_before = *left_counter.lock().await;
-    let right_before = *right_counter.lock().await;
+    let left_before = left_counter.load(Ordering::Relaxed);
+    let right_before = right_counter.load(Ordering::Relaxed);
 
     Timer::after(Duration::from_millis(interval_ms)).await;
 
-    let left_after = *left_counter.lock().await;
-    let right_after = *right_counter.lock().await;
+    let left_after = left_counter.load(Ordering::Relaxed);
+    let right_after = right_counter.load(Ordering::Relaxed);
 
     let delta_l = left_after.wrapping_sub(left_before) as f32;
     let delta_r = right_after.wrapping_sub(right_before) as f32;
@@ -171,19 +164,19 @@ pub async fn get_rpms(
 }
 
 pub async fn get_wheel_speed_in_rad(
-    left_counter: &'static Mutex<NoopRawMutex, i32>,
-    right_counter: &'static Mutex<NoopRawMutex, i32>,
+    left_counter: &'static AtomicI32,
+    right_counter: &'static AtomicI32,
     cpr_wheel: f32,
     interval_ms: u64,
     dt: f32, // equal to interval_ms but in second, just for saving one divide calculation
 ) -> (f32, f32) {
-    let left_before = *left_counter.lock().await;
-    let right_before = *right_counter.lock().await;
+    let left_before = left_counter.load(Ordering::Relaxed);
+    let right_before = right_counter.load(Ordering::Relaxed);
 
     Timer::after(Duration::from_millis(interval_ms)).await;
 
-    let left_after = *left_counter.lock().await;
-    let right_after = *right_counter.lock().await;
+    let left_after = left_counter.load(Ordering::Relaxed);
+    let right_after = right_counter.load(Ordering::Relaxed);
 
     let delta_l = left_after.wrapping_sub(left_before) as f32;
     let delta_r = right_after.wrapping_sub(right_before) as f32;
@@ -196,21 +189,15 @@ pub async fn get_wheel_speed_in_rad(
 }
 
 pub async fn wheel_speed_from_counts_now(
-    left_counter: &Mutex<NoopRawMutex, i32>,
-    right_counter: &Mutex<NoopRawMutex, i32>,
+    left_counter: &AtomicI32,
+    right_counter: &AtomicI32,
     cpr_wheel: f32,
     prev_left: i32,
     prev_right: i32,
     dt: f32, // in sec
 ) -> ((f32, f32), (i32, i32)) {
-    // Always acquire the lock to guarantee a valid count.
-    // try_lock() + unwrap_or(&0) would produce a delta of -absolute_count
-    // (potentially thousands of counts) if the lock is held by another task.
-    let (left_now, right_now) = {
-        let l = *left_counter.lock().await;
-        let r = *right_counter.lock().await;
-        (l, r)
-    };
+    let left_now = left_counter.load(Ordering::Relaxed);
+    let right_now = right_counter.load(Ordering::Relaxed);
 
     let delta_l = left_now.wrapping_sub(prev_left) as f32;
     let delta_r = right_now.wrapping_sub(prev_right) as f32;
@@ -221,13 +208,3 @@ pub async fn wheel_speed_from_counts_now(
 
     ((omega_l, omega_r), (left_now, right_now))
 }
-
-// // fast left position reading
-// pub fn read_left_count(counter: &'static Mutex<NoopRawMutex, i32>) -> i32 {
-//     counter.try_lock().map(|g| *g).unwrap_or(0)
-// }
-
-// // fast right position reading
-// pub fn read_right_count(counter: &'static Mutex<NoopRawMutex, i32>) -> i32 {
-//     counter.try_lock().map(|g| *g).unwrap_or(0)
-// }

--- a/firmware/src/encoder_lib.rs
+++ b/firmware/src/encoder_lib.rs
@@ -46,7 +46,7 @@ impl<'a, PIO: Instance> PioEncoderProgram<'a, PIO> {
 
 /// Pio Backed quadrature encoder reader
 pub struct PioEncoder<'d, T: Instance, const SM: usize> {
-    sm: StateMachine<'d, T, SM>,
+    _sm: StateMachine<'d, T, SM>,
 }
 
 impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
@@ -75,33 +75,7 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
         cfg.use_program(&program.prg, &[]);
         sm.set_config(&cfg);
         sm.set_enable(true);
-        Self { sm }
+        Self { _sm: sm }
     }
 
-    /// Read a single count from the encoder
-    pub async fn read(&mut self) -> Direction {
-        loop {
-            match self.sm.rx().wait_pull().await {
-                0 => return Direction::CounterClockwise,
-                1 => return Direction::Clockwise,
-                _ => {}
-            }
-        }
-    }
-
-    pub async fn read_ab(&mut self) -> u8 {
-        (self.sm.rx().wait_pull().await & 0b11) as u8
-    }
-
-    pub fn try_read_ab(&mut self) -> Option<u8> {
-        self.sm.rx().try_pull().map(|v| (v & 0b11) as u8)
-    }
-}
-
-/// Encoder Count Direction
-pub enum Direction {
-    /// Encoder turned clockwise
-    Clockwise,
-    /// Encoder turned counter clockwise
-    CounterClockwise,
 }

--- a/firmware/src/init.rs
+++ b/firmware/src/init.rs
@@ -28,7 +28,7 @@ use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::mutex::Mutex;
 
 bind_interrupts!(struct Irqs {
-    PIO0_IRQ_0 => PIO_INT_HDL<PIO0>;
+    PIO0_IRQ_0 => PIO_INT_HDL<PIO0>, crate::encoder::EncoderPioIrqHandler;
     I2C0_IRQ => I2C_INT_HDL<I2C0>;
     UART0_IRQ => UART_INT_HDL<UART0>;
 });

--- a/firmware/src/inner_controller.rs
+++ b/firmware/src/inner_controller.rs
@@ -8,6 +8,7 @@ use embassy_time::{Duration, Instant, Ticker, Timer};
 use portable_atomic::{AtomicI32, AtomicU32, Ordering};
 
 static INNER_LOOP_TICK: AtomicU32 = AtomicU32::new(0);
+const USE_ENCODER_LP_FILTER: bool = false;  // flag to activate encoder low pass filter
 
 #[embassy_executor::task]
 pub async fn wheel_speed_inner_loop(
@@ -30,7 +31,7 @@ pub async fn wheel_speed_inner_loop(
 
     // =========== Filter Parameters ==============
     let dt: f32 = period_ms as f32 / 1000.0;
-    let fc_hz: f32 = 3.0;
+    let fc_hz: f32 = 3.0; // -> tau = 53 ms, quite heavy smoothing
     let tau: f32 = 1.0 / (2.0 * core::f32::consts::PI * fc_hz);
     let alpha: f32 = dt / (tau + dt);
 
@@ -108,20 +109,21 @@ pub async fn wheel_speed_inner_loop(
         last_sample = Instant::now();
 
         // =========== Low Pass Filter ==============
-        omega_l_lp = omega_l_lp + alpha * (omega_l_raw - omega_l_lp);
-        omega_r_lp = omega_r_lp + alpha * (omega_r_raw - omega_r_lp);
-
-        // Optionally disable low-pass filter for testing
-        // omega_l_lp = omega_l_raw;
-        // omega_r_lp = omega_r_raw;
+        if USE_ENCODER_LP_FILTER {
+            omega_l_lp = omega_l_lp + alpha * (omega_l_raw - omega_l_lp);
+            omega_r_lp = omega_r_lp + alpha * (omega_r_raw - omega_r_lp);
+        } else {
+            omega_l_lp = omega_l_raw;
+            omega_r_lp = omega_r_raw;
+        }
 
         // error
         let el = last_cmd.omega_l - omega_l_lp;
         let er = last_cmd.omega_r - omega_r_lp;
 
         // error integration
-        il = (il + ki * dt * el).clamp(-2.0, 2.0);
-        ir = (ir + ki * dt * er).clamp(-2.0, 2.0);
+        il = (il + ki * dt * el).clamp(-0.8, 0.8);
+        ir = (ir + ki * dt * er).clamp(-0.8, 0.8);
 
         // error differentiation
         let dl = (el - prev_el) / dt;

--- a/firmware/src/inner_controller.rs
+++ b/firmware/src/inner_controller.rs
@@ -4,18 +4,16 @@ use crate::orchestrator_signal::{STOP_WHEEL_INNER_SIG, TRAJ_PAUSE_SIG, TRAJ_RESU
 use crate::read_robot_config_from_sd::RobotConfig;
 use crate::robotstate::{self, WheelCmd, WHEEL_CMD_CH};
 use embassy_futures::select::{select, select3, Either, Either3};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use portable_atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicI32, AtomicU32, Ordering};
 
 static INNER_LOOP_TICK: AtomicU32 = AtomicU32::new(0);
 
 #[embassy_executor::task]
 pub async fn wheel_speed_inner_loop(
     motor: MotorController,
-    left_counter: &'static Mutex<NoopRawMutex, i32>,
-    right_counter: &'static Mutex<NoopRawMutex, i32>,
+    left_counter: &'static AtomicI32,
+    right_counter: &'static AtomicI32,
     cfg: Option<RobotConfig>,
     period_ms: u64,
 ) {
@@ -41,8 +39,8 @@ pub async fn wheel_speed_inner_loop(
     let mut ticker = Ticker::every(Duration::from_millis(period_ms));
 
     //need to get current state of the encoders, because it is potentially leading to v spikes when switching programs.
-    let mut prev_l = *left_counter.lock().await;
-    let mut prev_r = *right_counter.lock().await;
+    let mut prev_l = left_counter.load(Ordering::Relaxed);
+    let mut prev_r = right_counter.load(Ordering::Relaxed);
     let mut last_sample = Instant::now();
 
     let mut omega_l_lp: f32 = 0.0;
@@ -74,8 +72,8 @@ pub async fn wheel_speed_inner_loop(
                 il = 0.0; ir = 0.0;
                 prev_el = 0.0; prev_er = 0.0;
                 omega_l_lp = 0.0; omega_r_lp = 0.0;
-                prev_l = *left_counter.lock().await;
-                prev_r = *right_counter.lock().await;
+                prev_l = left_counter.load(Ordering::Relaxed);
+                prev_r = right_counter.load(Ordering::Relaxed);
                 last_sample = Instant::now();
                 last_cmd = WheelCmd { omega_l: 0.0, omega_r: 0.0, stamp: Instant::now() };
                 continue;
@@ -95,7 +93,6 @@ pub async fn wheel_speed_inner_loop(
             let elapsed_s = (sample_now - last_sample).as_micros() as f32 / 1_000_000.0;
             if elapsed_s > 0.0 { elapsed_s } else { dt }
         };
-        last_sample = sample_now;
 
         // raw angular velocity of the wheel
         let ((omega_l_raw, omega_r_raw), (ln, rn)) = wheel_speed_from_counts_now(
@@ -108,10 +105,15 @@ pub async fn wheel_speed_inner_loop(
         ).await;
         prev_l = ln;
         prev_r = rn;
+        last_sample = Instant::now();
 
         // =========== Low Pass Filter ==============
         omega_l_lp = omega_l_lp + alpha * (omega_l_raw - omega_l_lp);
         omega_r_lp = omega_r_lp + alpha * (omega_r_raw - omega_r_lp);
+
+        // Optionally disable low-pass filter for testing
+        // omega_l_lp = omega_l_raw;
+        // omega_r_lp = omega_r_raw;
 
         // error
         let el = last_cmd.omega_l - omega_l_lp;

--- a/firmware/src/joystick_control.rs
+++ b/firmware/src/joystick_control.rs
@@ -8,11 +8,10 @@ use crate::uart_parser::{RecvResult, receive_packet};
 use crate::packet::CmdTeleopPacketMix;
 use crate::read_robot_config_from_sd::RobotConfig;
 use crate::trajectory_uart::UartCfg;
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::mutex::Mutex;
 use embassy_futures::select::{Either, select};
 use embassy_time::{Duration, Ticker};
 use heapless::Vec as HVec;
+use portable_atomic::{AtomicI32, Ordering};
 
 const PI: f32 = core::f32::consts::PI;
 const TELEOP_PACK_LEN: u8 = 9;
@@ -34,8 +33,8 @@ use crate::robotstate::{self, UnicycleCmd};
 pub async fn teleop_motor_control_task(
     //adapted from inner loop
     motor: MotorController,
-    left_counter: &'static Mutex<NoopRawMutex, i32>,
-    right_counter: &'static Mutex<NoopRawMutex, i32>,
+    left_counter: &'static AtomicI32,
+    right_counter: &'static AtomicI32,
     cfg: Option<RobotConfig>,
 ) {
     let robot_cfg: RobotConfig;
@@ -61,8 +60,8 @@ pub async fn teleop_motor_control_task(
     let alpha: f32 = dt / (tau + dt);
 
     // CRITICAL: Initialize prev encoder counts with CURRENT values to avoid velocity spike
-    let mut prev_l = *left_counter.lock().await;
-    let mut prev_r = *right_counter.lock().await;
+    let mut prev_l = left_counter.load(Ordering::Relaxed);
+    let mut prev_r = right_counter.load(Ordering::Relaxed);
 
     let mut omega_l_lp: f32 = 0.0;
     let mut omega_r_lp: f32 = 0.0;

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -11,7 +11,7 @@ use embassy_time::Timer;
 use pololu3pi2040_rs::{
     button::{button_task_b, button_task_c},
     // buzzer::play_startup_sound,
-    encoder::{EncoderPair, encoder_left_task, encoder_right_task},
+    encoder::start_encoder_irq,
     imu::read_imu_task,
     init::init_all,
     joystick_control::teleop_motor_control_task,
@@ -42,18 +42,9 @@ async fn main(spawner: Spawner) {
     spawner.spawn(button_task_c(buttons.btn_c)).unwrap();
 
     // === Encoder Task ===
-    let EncoderPair {
-        encoder_left,
-        encoder_right,
-    } = devices.encoders;
     let encoder_count_left = devices.encoder_counts.left;
     let encoder_count_right = devices.encoder_counts.right;
-    spawner
-        .spawn(encoder_left_task(encoder_left, encoder_count_left))
-        .unwrap();
-    spawner
-        .spawn(encoder_right_task(encoder_right, encoder_count_right))
-        .unwrap();
+    start_encoder_irq(devices.encoders);
 
     // === Motor Control Task ===
     // Start the PI controller task instead of direct motor control

--- a/firmware/src/odometry.rs
+++ b/firmware/src/odometry.rs
@@ -4,9 +4,8 @@ use crate::read_robot_config_from_sd::RobotConfig;
 use crate::robotstate;
 use defmt::info;
 use embassy_futures::select::{Either, select};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Instant, Ticker};
+use portable_atomic::{AtomicI32, Ordering};
 
 use crate::encoder::wheel_speed_from_counts_now;
 
@@ -39,8 +38,8 @@ impl OdometryData {
 //Responds to `STOP_ODOM_SIG` to cleanly exit when switching modes.
 #[embassy_executor::task]
 pub async fn odometry_task(
-    left_counter: &'static Mutex<NoopRawMutex, i32>,
-    right_counter: &'static Mutex<NoopRawMutex, i32>,
+    left_counter: &'static AtomicI32,
+    right_counter: &'static AtomicI32,
     cfg: Option<RobotConfig>,
     period_ms: u64,
 ) {
@@ -48,10 +47,8 @@ pub async fn odometry_task(
 
     let dt_nominal: f32 = period_ms as f32 / 1000.0;
     let mut ticker = Ticker::every(Duration::from_millis(period_ms));
-    // Use lock().await to guarantee a valid starting count (try_lock could return 0
-    // if the encoder task holds the mutex, causing a spurious spike on the first tick).
-    let mut prev_l: i32 = *left_counter.lock().await;
-    let mut prev_r: i32 = *right_counter.lock().await;
+    let mut prev_l: i32 = left_counter.load(Ordering::Relaxed);
+    let mut prev_r: i32 = right_counter.load(Ordering::Relaxed);
     let mut last_sample = Instant::now();
     let mut odom = OdometryData::new();
 
@@ -74,7 +71,6 @@ pub async fn odometry_task(
             let elapsed_s = (sample_now - last_sample).as_micros() as f32 / 1_000_000.0;
             if elapsed_s > 0.0 { elapsed_s } else { dt_nominal }
         };
-        last_sample = sample_now;
 
         // Raw angular velocity of each wheel [rad/s]
         let ((omega_l, omega_r), (ln, rn)) = wheel_speed_from_counts_now(
@@ -87,6 +83,8 @@ pub async fn odometry_task(
         ).await;
         prev_l = ln;
         prev_r = rn;
+
+        last_sample = Instant::now();
 
         // Differential-drive kinematics as measured (not from CMD_unicycle)
         let v = (robot_cfg.wheel_radius * (omega_r + omega_l)) / 2.0;

--- a/firmware/src/robotstate.rs
+++ b/firmware/src/robotstate.rs
@@ -625,10 +625,12 @@ pub async fn write_ekf_state(pose: RobotPose) {
         let mut guard = EKF_STATE.lock().await;
         *guard = pose;
     }
-    if is_sd_logging_active() {
-        let t_ms = embassy_time::Instant::now().as_millis() as u32;
-        let _ = LOG_EVENT_CH.try_send(LogEventWithTime { t_ms, event: LogEvent::EkfState(pose) });
-    }
+    // EKF state logging disabled to reduce SD log traffic / CPU load.
+    // Re-enable if fused pose rows are needed in the binary log again.
+    // if is_sd_logging_active() {
+    //     let t_ms = embassy_time::Instant::now().as_millis() as u32;
+    //     let _ = LOG_EVENT_CH.try_send(LogEventWithTime { t_ms, event: LogEvent::EkfState(pose) });
+    // }
 }
 
 /// Read latest EKF-fused pose
@@ -645,10 +647,12 @@ pub async fn write_odom(odom: OdomPose) {
         let mut guard = ODOM_STATE.lock().await;
         *guard = odom;
     }
-    if is_sd_logging_active() {
-        let t_ms = embassy_time::Instant::now().as_millis() as u32;
-        let _ = LOG_EVENT_CH.try_send(LogEventWithTime { t_ms, event: LogEvent::Odom(odom) });
-    }
+    // Odometry logging disabled to reduce SD log traffic / CPU load.
+    // Re-enable if v_actual/w_actual rows are needed in the binary log again.
+    // if is_sd_logging_active() {
+    //     let t_ms = embassy_time::Instant::now().as_millis() as u32;
+    //     let _ = LOG_EVENT_CH.try_send(LogEventWithTime { t_ms, event: LogEvent::Odom(odom) });
+    // }
 }
 pub async fn read_odom() -> OdomPose { *ODOM_STATE.lock().await }
 

--- a/firmware/src/sdlog.rs
+++ b/firmware/src/sdlog.rs
@@ -389,8 +389,8 @@ impl SdLogger {
 
 #[embassy_executor::task]
 pub async fn sd_logging_task(_cfg: Option<RobotConfig>) {
-    // Wait for everything to spin up
-    embassy_time::Timer::after_millis(500).await;
+    // Wait for everything to spin up + a small phase delay to avoid clashing with ctrl tasks
+    embassy_time::Timer::after_millis(507).await;
 
     let mut ticker = embassy_time::Ticker::every(embassy_time::Duration::from_millis(20)); // 50 Hz
 


### PR DESCRIPTION
Previously, encoder edges were buffered in the PIO RX FIFO and drained by normal Embassy tasks. Under heavier SD logging/control-loop load, those tasks could be delayed long enough for the FIFO to fill up or lag behind, causing periodic encoder velocity dips. The new implementation drains PIO0 SM0/SM1 RX FIFOs directly from PIO0_IRQ_0 and updates atomic encoder counters immediately.

Validated on a couple of test runs - readings are much smoother now, but some few jumps remain (does not seem to be related to this change, as this also appeared previously, see example below at around 3.5 s).

<img width="1416" height="581" alt="before_after_comparison" src="https://github.com/user-attachments/assets/911acb03-162a-44ba-922d-4932b384d147" />

